### PR TITLE
Add `getCache` and `execute` API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ yarn add lru-cache-for-clusters-as-promised
   * Get or update the `maxAge` value for the cache.
 * `stale([true|false])`
   * Get or update the `stale` value for the cache.
+* `execute(funcName, arg1, arg2, ...)`
+  * Execute arbitrary command (function) on the cache, returns whatever value was returned.
+* `getCache()`
+  * In Master, return the underlying LruCache instance (not as promise). In Worker, return null.
 
 # example usage
 **Master**

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,12 @@ declare module "lru-cache-for-clusters-as-promised" {
 
         // Get or update the stale value for the cache.
         stale(stale: boolean): Promise<void>
+
+        // Execute arbitrary command (function) on the cache.
+        execute(cmd: string, ...args: any[]): Promise<any>
+
+        // In Master, return the underlying LruCache instance. In Worker, return null.
+        getCache(): Object | null
     }
 
     // https://github.com/doublesharp/lru-cache-for-clusters-as-promised#options


### PR DESCRIPTION
While migrating from plain LruCache to the clustered version, I've realized that I had some custom "script" which temporarily overrided allowStale property, checked some cache values and wheter they were stale, and then restored allowStale back to original value.
I could not simply transform this into promised version, as executing the series of commands in promise chain would give a room for race conditions with other requests coming to master.
A solution for me was to create a custom method on LruCache, performing this chain of operations synchronously, and then calling that new custom method from workers. In order to achieve that, I've added 2 methods:
1. getCache, so that master can access underlying LruCache directly
2. execute, to invoke any arbitrary function.

I know described use-case is pretty unique, but I think these 2 new API methods give some extra power to library (ab)users in general.